### PR TITLE
Update makefile to add a `build_rules`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-all:
+all: build_rules
+	python3 scripts/lint_groups.py '../public/groups.json'
+	bash scripts/update-public-build.sh
+
+build_rules:
 	@echo
 	@echo "============================================================"
 	@echo "Using a pre-built binary for lint."
@@ -12,8 +16,6 @@ all:
 	python3 scripts/lint_src_json.py ../src/json
 	python3 scripts/lint_public_json.py ../public/json
 	bash scripts/apply-lint.sh '../public/json/*.json' --silent
-	python3 scripts/lint_groups.py '../public/groups.json'
-	bash scripts/update-public-build.sh
 
 rebuild:
 	touch ../src/json/*


### PR DESCRIPTION
It would be really useful to be able to pull in `core` to
a repo the same way `KE-complex_modifications` does. It's entirely
possible to make rules that are not useful or reasonable to have
polluting the public page.

This allows one to do that and run `make -C core build_rules`, which
will just build the rules without trying to build the 'groups' or
webpage stuff.

Currently this is how I have my repo setup, and then I simply symlink
`~/.config/karabiner/assets/<file>` to `<repo>/public/json/<file>`.

This modification has `all` call `build_rules`, so there's absolutely
no change in workflow for anyone contributing their rules to the
primary repo.
